### PR TITLE
fix(compose): context and paths

### DIFF
--- a/tools/image/compose.yml
+++ b/tools/image/compose.yml
@@ -1,14 +1,11 @@
 services:
   shacl_api:
-    environment:
-      env_file: .env.dist
     build:
-      context: ../..
-      dockerfile: ./tools/docker/Dockerfile
+      dockerfile: ./tools/image/Dockerfile
       target: webapp
     ports:
       - "8001:15400"
       - "8501:8501"
     volumes:
-      - ../../src:/shacl-api/src
+      - ./src:/shacl-api/src
     working_dir: /shacl-api


### PR DESCRIPTION
Hotfix for bug introduced in #12 the compose context was incorrectly set and did not work with `just image compose-up`.
This makes the compose file context-insensitive (i.e. we can move it around the repo without changing its contents), because\ the context specification is done in the compose command.